### PR TITLE
Added Get-PSHacktoberFestIssue function

### DIFF
--- a/docs/Get-PSHacktoberFestIssue.md
+++ b/docs/Get-PSHacktoberFestIssue.md
@@ -1,0 +1,107 @@
+---
+external help file: Get-PSGoodFirstIssue-help.xml
+Module Name: Get-PSGoodFirstIssue
+online version:
+schema: 2.0.0
+---
+
+# Get-PSHacktoberFestIssue
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-PSHacktoberFestIssue [[-OauthToken] <Object>] [[-Language] <Object>] [[-Label] <Object>]
+ [[-State] <Object>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Label
+{{Fill Label Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Language
+{{Fill Language Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OauthToken
+{{Fill OauthToken Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -State
+{{Fill State Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
### Using the `Get-PSHacktoberFestIssue` function:
```powershell
Get-PSHacktoberFestIssue -OauthToken $token
```
### Output:
```powershell
Title       : Add a a ToC to the resource section in the README.md
Repository  : PowerShell/xWebAdministration
Issue       : 450
Status      : open
Assigned to : Unassigned
Link        : https://github.com/PowerShell/xWebAdministration/issues/450
```

### Considerations:
Search API rate limiting is slightly different for authenticated and unauthenticated users

[Search Rate Limiting Docs](https://developer.github.com/v3/search/#rate-limit)

> The Search API has a custom rate limit. For requests using Basic Authentication, OAuth, or client ID and secret, you can make up to 30 requests per minute. For unauthenticated requests, the rate limit allows you to make up to 10 requests per minute.